### PR TITLE
remove unnecessary lookup for builds after 1616

### DIFF
--- a/util.py
+++ b/util.py
@@ -7,7 +7,7 @@ def safe_asm(bv, asm_str):
 
 def get_ssa_def(mlil, var):
     """ Gets the IL that defines var in the SSA form of mlil """
-    return mlil.ssa_form[mlil.ssa_form.get_ssa_var_definition(var)]
+    return mlil.ssa_form.get_ssa_var_definition(var)
 
 
 def gather_defs(il, defs):


### PR DESCRIPTION
we updated the API for builds after 1616 to remove this unnecessary lookup. The new API is backward compatible, but we're issuing PRs just to clean up the source code a bit so people are aware of the change. 