### PR TITLE
Fix get_var_uses returns ILs

### DIFF
--- a/deflatten.py
+++ b/deflatten.py
@@ -135,7 +135,7 @@ def compute_backbone_map(bv, mlil, state_var):
     uses += mlil.get_var_definitions(var)
 
     # Gather the blocks where this variable is used
-    blks = (b for idx in uses for b in mlil.basic_blocks if b.start <= idx < b.end)
+    blks = (b for il in uses for b in mlil.basic_blocks if b.start <= il.instr_index < b.end)
 
     # In each of these blocks, find the value of the state
     for bb in blks:

--- a/deflatten.py
+++ b/deflatten.py
@@ -188,7 +188,7 @@ def resolve_cfg_link(bv, mlil, il, backbone):
     bb = bv.get_basic_blocks_at(il.address)[0]
 
     # Unconditional jumps will set the state to a constant
-    if il.src.operation == MediumLevelILOperation.MLIL_CONST:
+    if il.src.operation == MediumLevelILOperation.MLIL_CONST or il.src.operation == MediumLevelILOperation.MLIL_CONST_PTR:
         return CFGLink(bb, backbone[il.src.constant], def_il=il)
 
     # Conditional jumps choose between two values


### PR DESCRIPTION
In the newest [Binary Ninja API](https://api.binary.ninja/_modules/binaryninja/mediumlevelil.html#MediumLevelILFunction.get_var_uses), ```get_var_uses``` returns list of IL which should not be compared with int.